### PR TITLE
Improve kitty page responsiveness and gallery

### DIFF
--- a/kitty.html
+++ b/kitty.html
@@ -3,6 +3,7 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Nuestros recuerdos 💖</title>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap" rel="stylesheet">
   <style>
@@ -22,23 +23,13 @@
       h2 {
         font-size: 1.3rem;
       }
-      .question p, .gallery-item {
-        font-size: 1rem;
-      }
-      .question button {
-        font-size: 0.9rem;
-        padding: 0.4rem 0.8rem;
-      }
-      .gallery-item {
-        padding: 0.8rem;
-      }
     }
     body {
       font-family: 'Nunito', sans-serif;
       background: linear-gradient(to bottom, #fff0f5, #ffe4ec);
       color: #c71585;
       margin: 0;
-      padding: 2rem;
+      padding: 1rem;
       text-align: center;
     }
     h1 {
@@ -50,19 +41,28 @@
       max-width: 700px;
       text-align: left;
     }
+    #progress {
+      text-align: center;
+      font-weight: bold;
+    }
     .question {
-      margin-bottom: 1rem;
+      margin-bottom: 1.5rem;
     }
     .question p {
       margin-bottom: 0.5rem;
       font-weight: bold;
     }
+    .options {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
     .question button {
+      flex: 1 1 100px;
       background: #ffb6c1;
       border: none;
       color: white;
       padding: 0.5rem 1rem;
-      margin: 0.3rem;
       border-radius: 20px;
       cursor: pointer;
     }
@@ -76,26 +76,52 @@
       padding: 1rem;
       margin-top: 1rem;
       box-shadow: 0 0 10px rgba(0,0,0,0.1);
+      text-align: center;
     }
     .gallery {
       margin-top: 3rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
     }
     .gallery-item {
       background: white;
       border: 2px solid #ffc0cb;
-      padding: 1rem;
       border-radius: 10px;
-      margin-bottom: 1rem;
+      overflow: hidden;
       cursor: pointer;
+    }
+    .gallery-item img {
+      width: 100%;
+      display: block;
+    }
+    .gallery-item figcaption {
+      padding: 0.5rem;
+      text-align: center;
     }
     .gallery-item:hover {
       background: #ffeef2;
     }
-    .gallery-image {
+    .lightbox {
       display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.8);
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+    }
+    .lightbox img {
+      max-width: 90%;
+      max-height: 80%;
+      border-radius: 10px;
+    }
+    .lightbox p {
+      color: white;
       margin-top: 1rem;
-      max-width: 100%;
-      border-radius: 8px;
     }
     a {
       display: inline-block;
@@ -103,6 +129,7 @@
       color: #ff69b4;
       font-weight: bold;
       text-decoration: none;
+      text-align: center;
     }
   </style>
 </head>
@@ -110,30 +137,46 @@
   <h1>💖 Cosas de Nosotros 💖</h1>
   <div class="section">
     <h2>Mini test de nuestra relación</h2>
-    <div class="question"><p>1. ¿Cuál es nuestro mote más usado?</p>
-      <button onclick="answer(0)">Pulgui</button>
-      <button onclick="answer(1)">Gatito</button>
-      <button onclick="answer(2)">Pulguita</button>
+    <p id="progress">0/5</p>
+    <div class="question">
+      <p>1. ¿Cuál es nuestro mote más usado?</p>
+      <div class="options">
+        <button onclick="answer()">Pulgui</button>
+        <button onclick="answer()">Gatito</button>
+        <button onclick="answer()">Pulguita</button>
+      </div>
     </div>
-    <div class="question"><p>2. ¿Cuál es nuestro mes favorito?</p>
-      <button onclick="answer(1)">Octubre</button>
-      <button onclick="answer(2)">Febrero</button>
-      <button onclick="answer(0)">Diciembre</button>
+    <div class="question">
+      <p>2. ¿Cuál es nuestro mes favorito?</p>
+      <div class="options">
+        <button onclick="answer()">Octubre</button>
+        <button onclick="answer()">Febrero</button>
+        <button onclick="answer()">Diciembre</button>
+      </div>
     </div>
-    <div class="question"><p>3. ¿Qué canción es 'nuestra canción'?</p>
-      <button onclick="answer(2)">La de los besitos</button>
-      <button onclick="answer(0)">Yellow</button>
-      <button onclick="answer(1)">La de Ed Sheeran</button>
+    <div class="question">
+      <p>3. ¿Qué canción es 'nuestra canción'?</p>
+      <div class="options">
+        <button onclick="answer()">La de los besitos</button>
+        <button onclick="answer()">Yellow</button>
+        <button onclick="answer()">La de Ed Sheeran</button>
+      </div>
     </div>
-    <div class="question"><p>4. ¿Qué película vimos en nuestra primera cita?</p>
-      <button onclick="answer(1)">Your Name</button>
-      <button onclick="answer(0)">Shrek</button>
-      <button onclick="answer(2)">No recuerdo, solo miraba tus ojos</button>
+    <div class="question">
+      <p>4. ¿Qué película vimos en nuestra primera cita?</p>
+      <div class="options">
+        <button onclick="answer()">Your Name</button>
+        <button onclick="answer()">Shrek</button>
+        <button onclick="answer()">No recuerdo, solo miraba tus ojos</button>
+      </div>
     </div>
-    <div class="question"><p>5. ¿Qué animal representa nuestro amor?</p>
-      <button onclick="answer(2)">Dos pingüinitos</button>
-      <button onclick="answer(0)">Un panda y un gato</button>
-      <button onclick="answer(1)">Dos koalas</button>
+    <div class="question">
+      <p>5. ¿Qué animal representa nuestro amor?</p>
+      <div class="options">
+        <button onclick="answer()">Dos pingüinitos</button>
+        <button onclick="answer()">Un panda y un gato</button>
+        <button onclick="answer()">Dos koalas</button>
+      </div>
     </div>
     <div class="result" id="result">
       <h3>¡Conoces nuestra historia de amor! 💕</h3>
@@ -143,33 +186,44 @@
 
   <div class="gallery section">
     <h2>📸 Nuestros recuerdos</h2>
-    <div class="gallery-item" onclick="toggleImage('img1')">
-      Nuestro primer viaje ✈️
-      <img id="img1" class="gallery-image" src="https://placekitten.com/600/400" alt="Nuestro primer viaje">
-    </div>
-    <div class="gallery-item" onclick="toggleImage('img2')">
-      Nuestra primera foto juntos 📷
-      <img id="img2" class="gallery-image" src="https://placekitten.com/601/401" alt="Nuestra primera foto">
-    </div>
-    <div class="gallery-item" onclick="toggleImage('img3')">
-      Un día cualquiera contigo 💗
-      <img id="img3" class="gallery-image" src="https://placekitten.com/602/402" alt="Un día contigo">
-    </div>
+    <figure class="gallery-item" onclick="openLightbox('https://placekitten.com/600/400','Nuestro primer viaje ✈️')">
+      <img src="https://placekitten.com/600/400" alt="Nuestro primer viaje">
+      <figcaption>Nuestro primer viaje ✈️</figcaption>
+    </figure>
+    <figure class="gallery-item" onclick="openLightbox('https://placekitten.com/601/401','Nuestra primera foto juntos 📷')">
+      <img src="https://placekitten.com/601/401" alt="Nuestra primera foto">
+      <figcaption>Nuestra primera foto juntos 📷</figcaption>
+    </figure>
+    <figure class="gallery-item" onclick="openLightbox('https://placekitten.com/602/402','Un día cualquiera contigo 💗')">
+      <img src="https://placekitten.com/602/402" alt="Un día contigo">
+      <figcaption>Un día cualquiera contigo 💗</figcaption>
+    </figure>
+  </div>
+
+  <div id="lightbox" class="lightbox" onclick="closeLightbox()">
+    <img id="lightbox-img" src="" alt="">
+    <p id="lightbox-caption"></p>
   </div>
 
   <a href="index.html">← Volver al inicio</a>
 
   <script>
-    let responses = [];
-    function answer(val) {
-      responses.push(val);
-      if (responses.length === 5) {
+    let answered = 0;
+    function answer() {
+      answered++;
+      document.getElementById('progress').textContent = `${answered}/5`;
+      if (answered === 5) {
         document.getElementById('result').style.display = 'block';
       }
     }
-    function toggleImage(id) {
-      const img = document.getElementById(id);
-      img.style.display = img.style.display === 'block' ? 'none' : 'block';
+    function openLightbox(src, caption) {
+      const lightbox = document.getElementById('lightbox');
+      document.getElementById('lightbox-img').src = src;
+      document.getElementById('lightbox-caption').textContent = caption;
+      lightbox.style.display = 'flex';
+    }
+    function closeLightbox() {
+      document.getElementById('lightbox').style.display = 'none';
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Enhance mobile experience with viewport meta tag and flexible layout for quiz options.
- Add progress indicator to relationship quiz and refine styling.
- Replace toggled gallery with responsive grid and lightbox viewer.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a201ed02d4832b9bbfbede68d83c10